### PR TITLE
Little sugar to the http_request:respond function

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -328,7 +328,9 @@ respond({Code, ResponseHeaders, Body}) ->
         _ ->
             send(Body)
     end,
-    Response.
+    Response;
+respond({Code}) ->
+  respond({Code, [], []}).
 
 %% @spec not_found() -> response()
 %% @doc Alias for <code>not_found([])</code>.


### PR DESCRIPTION
Hello!

I've added a little sugar to the http_request:respond function. Just it. Because sometimes I'd like to call respond({Code}) without specify headers and a body. I think it's util. At least to me.

If you also like it please merge it.

Best regards!
