### PR TITLE
Error name clash

### DIFF
--- a/support/make_app.escript
+++ b/support/make_app.escript
@@ -21,7 +21,7 @@ write_app(F, Comments, TermL, App) ->
                     file:close(Fd)
                 end;
         Error ->
-            error(Error)
+            mochi_error(Error)
     end.
 
 parse_appsrc(F) ->
@@ -39,13 +39,13 @@ parse_appsrc(F) ->
                         {ok, {application, _A, _Attrs} = App} ->
                             {Comments, TermL, App};
                         Error ->
-                            error(Error)
+                            mochi_error(Error)
                     end;
                 ScanErr ->
-                    error(ScanErr)
+                    mochi_error(ScanErr)
             end;
         ReadErr ->
-            error(ReadErr)
+            mochi_error(ReadErr)
     end.
 
 write_comments(Comments, Fd) ->
@@ -81,6 +81,6 @@ descr(Attrs) ->
             D
     end.
 
-error(E) ->
+mochi_error(E) ->
     io:fwrite("*** ~p~n", [E]),
     halt(1).


### PR DESCRIPTION
There is a error/1 function defined in support/make_app.escript - it shadows built-in function erlang:error/1. See build logs (just grep for "ambiguous call of overridden auto-imported BIF error/1"):

http://koji.fedoraproject.org/koji/getfile?taskID=2496796&name=build.log

In fact this is only a warning and only visible on R14B (and maybe on R14A too) but anyway this should be fixed. See build log with this patch:

http://koji.fedoraproject.org/koji/getfile?taskID=2496846&name=build.log
