### PR TITLE
Fix for exit when parsing attributes without names

### DIFF
--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -537,7 +537,7 @@ tokenize_literal(Bin, S=#decoder{offset=O}) ->
                                     orelse C =:= $= ->
             %% Handle case where tokenize_literal would consume
             %% 0 chars. http://github.com/mochi/mochiweb/pull/13
-            {{data, [C], false}, ?INC_COL(S)};
+            {[C], ?INC_COL(S)};
         _ ->
             tokenize_literal(Bin, S, [])
     end.
@@ -1228,6 +1228,13 @@ parse_quoted_attr_test() ->
             { <<"img">>, [ { <<"src">>, <<"/images/icon>.png">> } ], [] }
         ]},
         mochiweb_html:parse(D2)),     
+    ok.
+
+parse_missing_attr_name_test() ->
+    D0 = <<"<html =black></html>">>,
+    ?assertEqual(
+        {<<"html">>, [ { <<"=">>, <<"=">> }, { <<"black">>, <<"black">> } ], [] },
+       mochiweb_html:parse(D0)),
     ok.
     
 -endif.


### PR DESCRIPTION
A previous commit of mine (d064e459da7665d8dd7aad6da63fce210c25452d) introduced an exit with a function-clause error when parsing faulty HTML containing attributes without names, such as: `<liclass="first">` or `<body=black>`. This commit provides a fix.
