### PR TITLE
Fix for parsing incorrect singleton-tags

### DIFF
--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -404,8 +404,8 @@ destack(TagName, Stack) when is_list(Stack) ->
                         {_, []} ->
                             %% Actually was a singleton
                             Stack;
-                        {Pre, [{T1, A1, []} | Post1]} ->
-                            [{T0, A0, [{T1, A1, lists:reverse(Pre)} | Post1]}
+                        {Pre, [{T1, A1, Acc1} | Post1]} ->
+                            [{T0, A0, [{T1, A1, Acc1 ++ lists:reverse(Pre)} | Post1]}
                              | Post0]
                     end;
                 _ ->
@@ -1251,4 +1251,14 @@ parse_broken_pi_test() ->
 		mochiweb_html:parse(D0)),
 	ok.
     
+parse_funny_singletons_test() ->
+    D0 = <<"<html><input><input>x</input></input></html>">>,
+    ?assertEqual(
+        {<<"html">>, [], [
+            { <<"input">>, [], [] },
+            { <<"input">>, [], [ <<"x">> ] }
+        ] },
+        mochiweb_html:parse(D0)),
+    ok.
+
 -endif.


### PR DESCRIPTION
There's a small bug in the mochiweb HTML parser -- when it encounters incorrect singleton tags in a particular way, it crashes:

```
  1> mochiweb_html:parse("<html><input><input>x</input></input></html>").
  ** exception error: no case clause matching
                        {[],[{<<"input">>,[],[<<"x">>]},{<<"input">>,[],[]}]
       in function  mochiweb_html:destack/2
       in call from mochiweb_html:tree/2
       in call from mochiweb_html:parse_tokens/1
```

This patch provides a fix.
