### PR TITLE
Fixing up eunit includes.

### DIFF
--- a/src/mochifmt_records.erl
+++ b/src/mochifmt_records.erl
@@ -33,6 +33,6 @@ get_rec_index(Atom, [_ | Rest], Index) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochifmt_std.erl
+++ b/src/mochifmt_std.erl
@@ -25,6 +25,6 @@ format_field(Arg, Format) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiglobal.erl
+++ b/src/mochiglobal.erl
@@ -77,8 +77,8 @@ term_to_abstract(Module, Getter, T) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 get_put_delete_test() ->
     K = '$$test$$mochiglobal',
     delete(K),

--- a/src/mochilogfile2.erl
+++ b/src/mochilogfile2.erl
@@ -57,8 +57,8 @@ find_last_newline(FD, Location) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 name_test() ->
     D = mochitemp:mkdtemp(),
     FileName = filename:join(D, "open_close_test.log"),

--- a/src/mochitemp.erl
+++ b/src/mochitemp.erl
@@ -135,8 +135,9 @@ normalize_dir(L) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 pushenv(L) ->
     [{K, os:getenv(K)} || K <- L].
 popenv(L) ->

--- a/src/mochiweb_acceptor.erl
+++ b/src/mochiweb_acceptor.erl
@@ -43,6 +43,6 @@ call_loop(Loop, Socket) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_app.erl
+++ b/src/mochiweb_app.erl
@@ -22,6 +22,6 @@ stop(_State) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_cover.erl
+++ b/src/mochiweb_cover.erl
@@ -46,8 +46,8 @@ clause_fold(_, Acc) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 foo_table(a) -> b;
 foo_table("a") -> <<"b">>;
 foo_table(123) -> {4, 3, 2};

--- a/src/mochiweb_echo.erl
+++ b/src/mochiweb_echo.erl
@@ -33,6 +33,6 @@ loop(Socket) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_io.erl
+++ b/src/mochiweb_io.erl
@@ -40,7 +40,4 @@ iodevice_size(IoDevice) ->
 %%
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
-
-
-
 -endif.

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -764,6 +764,6 @@ accepts_content_type(ContentType1) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_response.erl
+++ b/src/mochiweb_response.erl
@@ -59,6 +59,6 @@ write_chunk(Data) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_skel.erl
+++ b/src/mochiweb_skel.erl
@@ -81,6 +81,6 @@ ensuredir(Dir) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/mochiweb_sup.erl
+++ b/src/mochiweb_sup.erl
@@ -36,6 +36,6 @@ init([]) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/reloader.erl
+++ b/src/reloader.erl
@@ -156,6 +156,6 @@ stamp() ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 -endif.


### PR DESCRIPTION
Consistently include eunit from inside the ifdef(TEST) blocks.  This avoids an eunit dependency during non-test compilation.
