### PR TITLE
Mochiweb should not rely on crypto application.

### DIFF
--- a/src/mochitemp.erl
+++ b/src/mochitemp.erl
@@ -1,7 +1,7 @@
 %% @author Bob Ippolito <bob@mochimedia.com>
 %% @copyright 2010 Mochi Media, Inc.
 
-%% @doc Create temporary files and directories. Requires crypto to be started.
+%% @doc Create temporary files and directories.
 
 -module(mochitemp).
 -export([gettempdir/0]).
@@ -87,7 +87,7 @@ rngchars(N) ->
     [rngchar() | rngchars(N - 1)].
 
 rngchar() ->
-    rngchar(crypto:rand_uniform(0, tuple_size(?SAFE_CHARS))).
+    rngchar(mochiweb_util:rand_uniform(0, tuple_size(?SAFE_CHARS))).
 
 rngchar(C) ->
     element(1 + C, ?SAFE_CHARS).
@@ -177,7 +177,6 @@ gettempdir_cwd_test() ->
     ok.
 
 rngchars_test() ->
-    crypto:start(),
     ?assertEqual(
        "",
        rngchars(0)),
@@ -199,7 +198,6 @@ rngchar_test() ->
     ok.
 
 mkdtemp_n_failonce_test() ->
-    crypto:start(),
     D = mkdtemp(),
     Path = filename:join([D, "testdir"]),
     %% Toggle the existence of a dir so that it fails
@@ -246,7 +244,6 @@ make_dir_fail_test() ->
     ok.
 
 mkdtemp_test() ->
-    crypto:start(),
     D = mkdtemp(),
     ?assertEqual(
        true,
@@ -257,7 +254,6 @@ mkdtemp_test() ->
     ok.
 
 rmtempdir_test() ->
-    crypto:start(),
     D1 = mkdtemp(),
     ?assertEqual(
        true,

--- a/src/mochiweb.app.src
+++ b/src/mochiweb.app.src
@@ -6,4 +6,4 @@
   {registered, []},
   {mod, {mochiweb_app, []}},
   {env, []},
-  {applications, [kernel, stdlib, crypto, inets]}]}.
+  {applications, [kernel, stdlib, inets]}]}.

--- a/src/mochiweb.erl
+++ b/src/mochiweb.erl
@@ -13,14 +13,12 @@
 %% @spec start() -> ok
 %% @doc Start the MochiWeb server.
 start() ->
-    ensure_started(crypto),
     application:start(mochiweb).
 
 %% @spec stop() -> ok
 %% @doc Stop the MochiWeb server.
 stop() ->
     Res = application:stop(mochiweb),
-    application:stop(crypto),
     Res.
 
 reload() ->
@@ -77,16 +75,6 @@ new_response({Request, Code, Headers}) ->
     mochiweb_response:new(Request,
                           Code,
                           mochiweb_headers:make(Headers)).
-
-%% Internal API
-
-ensure_started(App) ->
-    case application:start(App) of
-        ok ->
-            ok;
-        {error, {already_started, App}} ->
-            ok
-    end.
 
 
 %%
@@ -195,7 +183,7 @@ do_POST(Transport, Size, Times) ->
                 end,
     TestReqs = [begin
                     Path = "/stuff/" ++ integer_to_list(N),
-                    Body = crypto:rand_bytes(Size),
+                    Body = mochiweb_util:rand_bytes(Size),
                     #treq{path=Path, body=Body, xreply=Body}
                 end || N <- lists:seq(1, Times)],
     ClientFun = new_client_fun('POST', TestReqs),

--- a/src/mochiweb_multipart.erl
+++ b/src/mochiweb_multipart.erl
@@ -38,7 +38,7 @@ parts_to_body([{Start, End, Body}], ContentType, Size) ->
     {HeaderList, Body};
 parts_to_body(BodyList, ContentType, Size) when is_list(BodyList) ->
     parts_to_multipart_body(BodyList, ContentType, Size,
-                            mochihex:to_hex(crypto:rand_bytes(8))).
+                            mochihex:to_hex(mochiweb_util:rand_bytes(8))).
 
 %% @spec parts_to_multipart_body([bodypart()], ContentType::string(),
 %%                               Size::integer(), Boundary::string()) ->

--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -119,7 +119,6 @@ parse_options([{profile_fun, ProfileFun} | Rest], State) when is_function(Profil
 start_server(State=#mochiweb_socket_server{ssl=Ssl, name=Name}) ->
     case Ssl of
         true ->
-            application:start(crypto),
             application:start(public_key),
             application:start(ssl);
         false ->

--- a/src/mochiweb_util.erl
+++ b/src/mochiweb_util.erl
@@ -13,7 +13,7 @@
 -export([record_to_proplist/2, record_to_proplist/3]).
 -export([safe_relative_path/1, partition/2]).
 -export([parse_qvalues/1, pick_accepted_encodings/3]).
--export([make_io/1]).
+-export([make_io/1, rand_bytes/1, rand_uniform/2]).
 
 -define(PERCENT, 37).  % $\%
 -define(FULLSTOP, 46). % $\.
@@ -574,6 +574,16 @@ make_io(Integer) when is_integer(Integer) ->
     integer_to_list(Integer);
 make_io(Io) when is_list(Io); is_binary(Io) ->
     Io.
+
+rand_bytes(Count) ->
+    list_to_binary([rand_uniform(0, 16#FF + 1) || _ <- lists:seq(1, Count)]).
+
+rand_uniform(Lo, Hi) ->
+    %% This stuff is not called anywhere performance critical,
+    %% it won't hurt to just initialize it every time.
+    {A, B, C} = now(),
+    random:seed(A, B, C),
+    random:uniform(Hi - Lo) + Lo - 1.
 
 %%
 %% Tests

--- a/support/templates/mochiwebapp_skel/src/mochiapp.app.src
+++ b/support/templates/mochiwebapp_skel/src/mochiapp.app.src
@@ -6,4 +6,4 @@
   {registered, []},
   {mod, {'{{appid}}_app', []}},
   {env, []},
-  {applications, [kernel, stdlib, crypto]}]}.
+  {applications, [kernel, stdlib]}]}.

--- a/support/templates/mochiwebapp_skel/src/mochiapp.erl
+++ b/support/templates/mochiwebapp_skel/src/mochiapp.erl
@@ -20,7 +20,6 @@ ensure_started(App) ->
 %% @doc Start the {{appid}} server.
 start() ->
     {{appid}}_deps:ensure(),
-    ensure_started(crypto),
     application:start({{appid}}).
 
 


### PR DESCRIPTION
There is no reason for mochiweb to use crypto application. It's an unnecessary dependency, and it's pretty hard get crypto working to in some environments.

Mochiweb doesn't need cryptographically strong random numbers.

(the changes originally created by Emile and Simon from RabbitMQ)
