### PR TITLE
Removed one mochiweb_request:accepts_content_type/1 function clause

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -727,8 +727,6 @@ accepted_encodings(SupportedEncodings) ->
 %%      5) For an "Accept" header with value "text/*; q=0.0, */*":
 %%         accepts_content_type("text/plain") -> false
 %%
-accepts_content_type(ContentType) when is_binary(ContentType) ->
-    accepts_content_type(binary_to_list(ContentType));
 accepts_content_type(ContentType1) ->
     ContentType = re:replace(ContentType1, "\\s", "", [global, {return, list}]),
     AcceptHeader = case get_header_value("Accept") of

--- a/src/mochiweb_request_tests.erl
+++ b/src/mochiweb_request_tests.erl
@@ -7,6 +7,7 @@ accepts_content_type_test() ->
     Req1 = mochiweb_request:new(nil, 'GET', "/foo", {1, 1},
         mochiweb_headers:make([{"Accept", "multipart/related"}])),
     ?assertEqual(true, Req1:accepts_content_type("multipart/related")),
+    ?assertEqual(true, Req1:accepts_content_type(<<"multipart/related">>)),
 
     Req2 = mochiweb_request:new(nil, 'GET', "/foo", {1, 1},
         mochiweb_headers:make([{"Accept", "text/html"}])),


### PR DESCRIPTION
This was not a necessary clause because the regexp replace operation
accepts iolists.
