### PR TITLE
Allow explicit Content-Type while serving file

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -605,8 +605,12 @@ maybe_serve_file(File, ExtraHeaders) ->
                 _ ->
                     case file:open(File, [raw, binary]) of
                         {ok, IoDevice} ->
-                            ContentType = mochiweb_util:guess_mime(File),
-                            Res = ok({ContentType,
+                            CType = case proplists:get_value("Content-Type",
+                                    ExtraHeaders) of
+                                undefined -> mochiweb_util:guess_mime(File);
+                                X -> X
+                            end,
+                            Res = ok({CType,
                                       [{"last-modified", LastModified}
                                        | ExtraHeaders],
                                       {file, IoDevice}}),


### PR DESCRIPTION
When using Req:serve_file/3 with Content-Type ExtraHeader, it is being
overwritten by mochiweb_util:guess_mime/1. This patch makes it check if
Content-Type is not defined before serving the file. If defined, leave
Content-Type intact.
