### PR TITLE
add json_encode for associative list to an object

### DIFF
--- a/src/mochijson.erl
+++ b/src/mochijson.erl
@@ -118,6 +118,8 @@ json_encode(F, _State) when is_float(F) ->
     mochinum:digits(F);
 json_encode(L, State) when is_list(L); is_binary(L); is_atom(L) ->
     json_encode_string(L, State);
+json_encode([{_K,_V}|_PropsT]=Props, State) ->
+    json_encode_proplist(Props, State);
 json_encode({array, Props}, State) when is_list(Props) ->
     json_encode_array(Props, State);
 json_encode({struct, Props}, State) when is_list(Props) ->

--- a/src/mochijson2.erl
+++ b/src/mochijson2.erl
@@ -139,6 +139,8 @@ json_encode([{K, _}|_] = Props, State) when (K =/= struct andalso
     json_encode_proplist(Props, State);
 json_encode({struct, Props}, State) when is_list(Props) ->
     json_encode_proplist(Props, State);
+json_encode([{_K,_V}|_PropsT]=Props, State) ->
+    json_encode_proplist(Props, State);
 json_encode(Array, State) when is_list(Array) ->
     json_encode_array(Array, State);
 json_encode({array, Array}, State) when is_list(Array) ->


### PR DESCRIPTION
lists of the type [{K,V},...] get encoded into a json object.
without this change, input of that structure just crashes.

it's a lot easier to get data into the associative list format than into the {struct, [{K,V}]} format
