### PR TITLE
Add encoder option to turn off default encoding of atoms into unicode strings

### DIFF
--- a/src/mochijson2.erl
+++ b/src/mochijson2.erl
@@ -135,7 +135,9 @@ json_encode(I, _State) when is_integer(I) ->
     integer_to_list(I);
 json_encode(F, _State) when is_float(F) ->
     mochinum:digits(F);
-json_encode(S, State=#encoder{encode_atoms=true}) when is_binary(S); is_atom(S) ->
+json_encode(S, State) when is_binary(S) ->
+    json_encode_string(S, State);
+json_encode(S, State=#encoder{encode_atoms=true}) when is_atom(S) ->
     json_encode_string(S, State);
 json_encode([{K, _}|_] = Props, State) when (K =/= struct andalso
                                              K =/= array andalso


### PR DESCRIPTION
The option encode_atoms was added to #encoder{} in mochijson2.  Setting this option to false will cause json_encode to fail when encountering an atom other than true, false, null.  This will allow custom encoders to handle them.

Added this because I wanted to encode 'undefined' as <<"null">> using a custom encoder, but the default encoding would process them before the custom encoder was invoked.
