### PR TITLE
Added new MIME types

### DIFF
--- a/src/mochiweb_mime.erl
+++ b/src/mochiweb_mime.erl
@@ -388,6 +388,8 @@ from_extension(".webp") ->
     "image/web";
 from_extension(".woff") ->
     "application/x-font-woff";
+from_extension(".otf") ->
+    "font/opentype";
 from_extension(_) ->
     undefined.
 


### PR DESCRIPTION
Added MIME types for eot, m4v, svg, svgz, ttc, ttf, vcf, webm, webp, woff & otf files. Started with webfonts but added some more types when at it. I used Paul Irish's Html5boilerplate as reference for the webfonts https://github.com/paulirish/html5-boilerplate/blob/master/.htaccess#L92.
