### PR TITLE
Prevent Unnecessary Socket Exceptions

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -320,11 +320,10 @@ respond({Code, ResponseHeaders, chunked}) ->
     start_response({Code, HResponse1});
 respond({Code, ResponseHeaders, Body}) ->
     Response = start_response_length({Code, ResponseHeaders, iolist_size(Body)}),
-    case Method of
-        'HEAD' ->
-            ok;
-        _ ->
-            send(Body)
+    if Method == 'HEAD'; Body == "" ->
+        ok;
+    _ ->
+        send(Body)
     end,
     Response.
 


### PR DESCRIPTION
We were seeing a lot of seemingly harmless socket exceptions in our system.  After a little digging, I found out that it's because the client is closing the socket as soon as it receives a complete message from mochiweb:respond().  Unfortunately, mochiweb:respond() would then try to send the body, even when it is blank (""), which was causing the exception.  This change cleans up those unnecessary exceptions.
