### PR TITLE
Fix for mochiweb_acceptor crash under R15B02

### DIFF
--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -66,6 +66,10 @@ request(Socket, Body) ->
         {ssl_closed, _} ->
             mochiweb_socket:close(Socket),
             exit(normal);
+        {tcp_error,_,emsgsize} ->
+            % R15B02 returns this then closes the socket, so close and exit
+            mochiweb_socket:close(Socket),
+            exit(normal);
         _Other ->
             handle_invalid_request(Socket)
     after ?REQUEST_RECV_TIMEOUT ->
@@ -93,6 +97,10 @@ headers(Socket, Request, Headers, Body, HeaderCount) ->
             headers(Socket, Request, [{Name, Value} | Headers], Body,
                     1 + HeaderCount);
         {tcp_closed, _} ->
+            mochiweb_socket:close(Socket),
+            exit(normal);
+        {tcp_error,_,emsgsize} ->
+            % R15B02 returns this then closes the socket, so close and exit
             mochiweb_socket:close(Socket),
             exit(normal);
         _Other ->


### PR DESCRIPTION
The source is still unclear but R15B02 now will return and emsgsize error
if the received packet is larger than the recvbuf.  This can be tested with
the following (sorry I don't know how to integrate this sort of test into
mochiweb's tests).

``` erlang
-module(mochi_test).

-export([start/0,
         handle_http/1,
         test/1]).

start() ->
  application:start (inets),
  mochiweb_http:start([{port, 5678}, {loop, fun(Req) -> handle_http(Req) end}]).

handle_http(Req) ->
  Req:respond({ 200,
                [ {"Content-Type", "text/html"} ],
                [ "<html><body>Hello</body></html>" ]
              }).

test (Len) ->
  httpc:request (get, {"http://127.0.0.1:5678/",
                 [{"X-Random", [$a || _ <- lists:seq(1,Len)]}]}, [], []).
```

Once compiled you can run this with

erl -pa ebin -boot start_sasl

Then run with

mochi_test:start().
mochi_test:test(10000).

The result is different with R14B04 and R15B02.  With R15B02 there was
a crash in the mochiweb_acceptor.  This patch deals with that crash.
