### PR TITLE
Make the acceptor crash optional.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,7 @@
 % -*- mode: erlang -*-
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info,
+            {platform_define, "(R14|R16)", 'gen_tcp_fix'}
+           ]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {dialyzer_opts, [{warnings, [no_return,

--- a/scripts/check_for_gen_tcp_fix.erl
+++ b/scripts/check_for_gen_tcp_fix.erl
@@ -1,0 +1,28 @@
+#!/usr/bin/env escript
+%% -*- mode: erlang -*-
+%%! -pa ../ebin
+-export([main/1]).
+
+main([]) ->
+  application:start (inets),
+  mochiweb_http:start([{port, 5678},
+                       {loop,
+                        fun(Req) ->
+                          Req:respond({ 200,
+                          [ {"Content-Type", "text/html"} ],
+                          [ "<html><body>Hello</body></html>" ]
+                       })
+                       end}]),
+
+  io:format ("~p~n",[not has_bug(1000) and not has_bug(10000)]).
+
+has_bug (Len) ->
+  case
+    httpc:request (get, {"http://127.0.0.1:5678/",
+                   [{"X-Random", [$a || _ <- lists:seq(1,Len)]}]}, [], [])
+  of
+    {error,socket_closed_remotely} -> true;
+    {ok,{{"HTTP/1.1",200,"OK"}, _, "<html><body>Hello</body></html>"}} -> false;
+    {ok,{{"HTTP/1.1",400,"Bad Request"}, _, []}} -> false;
+    R -> io:format ("don't know what to make of ~p~n",[R]), undefined
+  end.

--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -166,6 +166,7 @@ init(State=#mochiweb_socket_server{ip=Ip, port=Port, backlog=Backlog, nodelay=No
                 {packet, 0},
                 {backlog, Backlog},
                 {recbuf, ?RECBUF_SIZE},
+                {exit_on_close, false},
                 {active, false},
                 {nodelay, NoDelay}],
     Opts = case Ip of


### PR DESCRIPTION
So turns out the "Fix for mochiweb_acceptor crash under R15B02" from
https://github.com/mochi/mochiweb/pull/91 was a bug in OTP fixed in R16B.

https://github.com/erlang/otp/commit/6aa9e71dbb279a172b5a2c86f28cbfada1b68080

So it worked in R14, was broken in R15 and got fixed in R16.  This commit
makes it such that things will work as well as possible in each version.

In rebar.config I set a compiler option if on R14 or R16, in mochiweb_http.erl
I make the extra R15 clause be added with the macro, then in
mochiweb_socket_server.erl I add in { exit_on_close, false } to the options.

In addition there is a script which will detect if the fix is needed based
on my test case from issue 91.

Just run 'make ; cd scripts ; ./check_for_gen_tcp_fix.erl' and it should
return true if the fix is in place.
