### PR TITLE
Fix for Erlang R16B01

### DIFF
--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -137,6 +137,7 @@ start_server(F, State=#mochiweb_socket_server{ssl=Ssl, name=Name}) ->
 
 prep_ssl(true) ->
     ok = mochiweb:ensure_started(crypto),
+    ok = mochiweb:ensure_started(asn1),
     ok = mochiweb:ensure_started(public_key),
     ok = mochiweb:ensure_started(ssl);
 prep_ssl(false) ->


### PR DESCRIPTION
The public_key module from a very recent Erlang R16B01 requires that asn1 module must be started before. See these link for further details and Erlang user's weeps:
- http://thread.gmane.org/gmane.comp.lang.erlang.general/68995/focus=69001
- https://issues.apache.org/jira/browse/COUCHDB-1833
- http://thread.gmane.org/gmane.comp.networking.rabbitmq.general/23889
- http://thread.gmane.org/gmane.comp.lang.erlang.general/69019

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
