### PR TITLE
Add support for possible outputs from 

### DIFF
--- a/src/mochiweb.erl
+++ b/src/mochiweb.erl
@@ -56,6 +56,23 @@ new_request({Socket, {Method, '*'=Uri, Version}, Headers}) ->
                          Method,
                          Uri,
                          Version,
+                         mochiweb_headers:make(Headers));
+%% Request URI is a scheme
+%% Erlang decode_package will return this for requests like `CONNECT example:port`
+new_request({Socket, {Method, {scheme, Hostname, Port}, Version}, Headers}) ->
+    Uri = Hostname ++ ":" ++ Port,
+    mochiweb_request:new(Socket,
+                         Method,
+                         Uri,
+                         Version,
+                         mochiweb_headers:make(Headers));
+%% Request is an HTTP string
+%% Erlang decode_package will return this for requests like `GET example`
+new_request({Socket, {Method, HttpString, Version}, Headers}) when is_list(HttpString) ->
+    mochiweb_request:new(Socket,
+                         Method,
+                         HttpString,
+                         Version,
                          mochiweb_headers:make(Headers)).
 
 %% @spec new_response({Request, integer(), Headers}) -> MochiWebResponse


### PR DESCRIPTION
I was having problems with mochiweb when a client issues an HTTP command like this:

```
CONNECT host:port HTTP/1.1
```

This will be decoded using `erlang:decode_package/3` and will cause an error in the file `mochiweb.erl` causing that acceptor to crash with a function clause error. This is happening because the output of `decode_packge/3` is `{scheme, HttpString, HttpString}` which is not handled in the function `mochiweb:new_request/1`.

I patched that file to support all possible outputs from `decode_package/3` so I'm able to return an error message to the clients. Both NGINX and Apache return 400 by default.

I'm not sure requests like this should be forwared to the user of the mochiweb server or just be unsupported. If they are supposed to be unsupported an error (400?) should probably be returned instead. 
