### PR TITLE
Crypto leap forward for R16B01+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 % -*- mode: erlang -*-
 {erl_opts, [debug_info,
-            {platform_define, "R15", 'gen_tcp_r15b_workaround'}]}.
+            {platform_define, "R15", 'gen_tcp_r15b_workaround'},
+            {platform_define, "(R14|R15|R16B-)", 'crypto_compatibility'}]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {dialyzer_opts, [{warnings, [no_return,


### PR DESCRIPTION
Starting R16B01, crypto functions for hashing and block encryption
are to be deprecated from their individual `crypto:Name(...)` form to
`crypto:Type(Name, ...)` as a form.

This pull req moves forward with the change, which is incompatible
with R16B and earlier versions. The `crypto:aes_cfb_128_encrypt/3`
and `crypto:aes_cfb_128_decrypt/3` functions are replaced by
`crypto:block_encrypt/4` and `crypto:block_decrypt/4`, which didn't yet
exist in R16B.

The pull req can be made backwards compatible on-demand by
using a `try ... catch` for `{error, undef}`, if requested.
