### PR TITLE
Adobe-valid MIME type for crossdomain.xml

### DIFF
--- a/src/mochiweb_util.erl
+++ b/src/mochiweb_util.erl
@@ -360,8 +360,8 @@ guess_mime(File) ->
     case filename:basename(File) of
         "crossdomain.xml" ->
             "text/x-cross-domain-policy";
-        _ ->
-            case mochiweb_mime:from_extension(filename:extension(File)) of
+        Name ->
+            case mochiweb_mime:from_extension(filename:extension(Name)) of
                 undefined ->
                     "text/plain";
                 Mime ->


### PR DESCRIPTION
http://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html

We are actually using the same content-type inside the ad server.
