### PR TITLE
Update test/mochiweb_tests.erl

### DIFF
--- a/test/mochiweb_tests.erl
+++ b/test/mochiweb_tests.erl
@@ -63,17 +63,21 @@ single_2k_http_POST_test() ->
 single_2k_https_POST_test() ->
     do_POST(ssl, 2048, 1).
 
-single_100k_http_POST_test() ->
-    do_POST(plain, 102400, 1).
+single_100k_http_POST_test_() -> % note the underscore
+    {timeout, ?LARGE_TIMEOUT,
+     fun() -> ?assertEqual(ok, do_POST(plain, 102400, 1)) end}.
 
-single_100k_https_POST_test() ->
-    do_POST(ssl, 102400, 1).
+single_100k_https_POST_test_() -> % note the underscore
+    {timeout, ?LARGE_TIMEOUT,
+     fun() -> ?assertEqual(ok, do_POST(ssl, 102400, 1)) end}.
 
 multiple_100k_http_POST_test() ->
-    do_POST(plain, 102400, 3).
+    {timeout, ?LARGE_TIMEOUT,
+     fun() -> ?assertEqual(ok, do_POST(plain, 102400, 3)) end}.
 
 multiple_100K_https_POST_test() ->
-    do_POST(ssl, 102400, 3).
+    {timeout, ?LARGE_TIMEOUT,
+     fun() -> ?assertEqual(ok, do_POST(ssl, 102400, 3)) end}.
 
 hundred_128_http_POST_test_() -> % note the underscore
     {timeout, ?LARGE_TIMEOUT,


### PR DESCRIPTION
- With Erlang R16B03 running on FreeBSD/amd64 10.0-PRERELEASE
  (base/stable/10 r260159),
  the following tests will not finish
  within the default eunit timeout of 5 seconds
  (See `lib/eunit/src/eunit_internal.hrl` (of R16B03))
  so cases modified to extend timeout to 60 seconds (`LARGE_TIMEOUT`):
  
  ```
    % note well the underscore at the end of function names
    single_100k_http_POST_test_()
    single_100k_https_POST_test_()
    multiple_100k_http_POST_test_()
    multiple_100k_https_POST_test_()
  ```
  
  See also https://github.com/mochi/mochiweb/commit/02066a511adcad08bb05d7a4a36ca1fc9ca08805
