### PR TITLE
support start a server listen on an opened socket

### DIFF
--- a/examples/multi_server/multi_server.erl
+++ b/examples/multi_server/multi_server.erl
@@ -1,0 +1,39 @@
+%%%-------------------------------------------------------------------
+%%% @author tianxiao@taobao.com
+%%% @copyright (C) 2014, <Taobao>
+%%% @doc test for server listen on an opened socket
+%%%
+%%% @end
+%%% Created : 22. Jan 2014 4:48 PM
+%%%-------------------------------------------------------------------
+-module(multi_server).
+-author("tianxiao").
+
+%% API
+-export([start/1, loop/1]).
+
+-define(LOOP, {?MODULE, loop}).
+
+start(Port) ->
+  Options = [{loop, ?LOOP}, {port, Port}, {acceptor_pool_size, 1}],
+%%   we start the first server
+  {ok, First} = mochiweb_http:start([{name, first_server} | Options]),
+
+%%   get the socket which first server listen on
+  {ok, ListenSocket} = mochiweb_socket_server:get(first_server, listen),
+
+  io:format("first server is started as process ~p, listen on socket ~p~n", [First, ListenSocket]),
+
+%%   We use the socket to create another server
+%%   For multiple server, the name option should be set as 'undefined' or uniquely among or server
+  {ok, Second} = mochiweb_http:start([{name, second_server} | Options], ListenSocket),
+
+%%   second server's socket should equal to the first
+  {ok, ListenSocket} = mochiweb_socket_server:get(second_server, listen),
+
+  io:format("second server is started as process ~p, listen on socket ~p~n", [Second, ListenSocket]).
+
+
+
+loop(Req) ->
+  Req:ok({"text/plain", [], io_lib:format("~p", [process_info(self(), links)])}).

--- a/src/mochiweb_acceptor.erl
+++ b/src/mochiweb_acceptor.erl
@@ -10,19 +10,19 @@
 
 -export([start_link/3, init/3]).
 
-start_link(Server, Listen, Loop) ->
-    proc_lib:spawn_link(?MODULE, init, [Server, Listen, Loop]).
+start_link(Server, ListenSocket, Loop) ->
+    proc_lib:spawn_link(?MODULE, init, [Server, ListenSocket, Loop]).
 
-init(Server, Listen, Loop) ->
+init(Server, ListenSocket, Loop) ->
     T1 = os:timestamp(),
-    case catch mochiweb_socket:accept(Listen) of
+    case catch mochiweb_socket:accept(ListenSocket) of
         {ok, Socket} ->
             gen_server:cast(Server, {accepted, self(), timer:now_diff(os:timestamp(), T1)}),
             call_loop(Loop, Socket);
         {error, closed} ->
             exit(normal);
         {error, timeout} ->
-            init(Server, Listen, Loop);
+            init(Server, ListenSocket, Loop);
         {error, esslaccept} ->
             exit(normal);
         Other ->

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -5,7 +5,7 @@
 
 -module(mochiweb_http).
 -author('bob@mochimedia.com').
--export([start/1, start_link/1, stop/0, stop/1]).
+-export([start/1, start_link/1, stop/0, stop/1, start/2]).
 -export([loop/2]).
 -export([after_response/2, reentry/1]).
 -export([parse_range_request/1, range_skip_length/2]).
@@ -36,8 +36,9 @@ stop(Name) ->
     mochiweb_socket_server:stop(Name).
 
 %% @spec start(Options) -> ServerRet
-%%     Options = [option()]
-%%     Option = {name, atom()} | {ip, string() | tuple()} | {backlog, integer()}
+%%    Options = [option()]
+%%    Option = {name, atom()} | | {loop, fun(Req)} | {port, integer()} | {ip, string()
+%%              | tuple()} | {backlog, integer()}
 %%              | {nodelay, boolean()} | {acceptor_pool_size, integer()}
 %%              | {ssl, boolean()} | {profile_fun, undefined | (Props) -> ok}
 %%              | {link, false}
@@ -48,6 +49,17 @@ stop(Name) ->
 %% @end
 start(Options) ->
     mochiweb_socket_server:start(parse_options(Options)).
+
+%% @spec start(Options, ListenSocket) -> ServerRet
+%%    Options = [option()]
+%%    Option = {name, atom()} | {loop, fun(Req)} | {acceptor_pool_size, integer()}
+%%              | {profile_fun, undefined | (Props) -> ok} | {link, false}
+%%    ListenSocket = {ssl, Socket} | Socket
+%% @doc start a server listen on an pre-opened socket. The port option is not needed any more. The opened socket can be fetched by call mochiweb_socket_server:get(Name, listen)
+%% @end
+start(Options, ListenSocket) ->
+  mochiweb_socket_server:start([{listen, ListenSocket} | parse_options(Options)]).
+
 
 start_link(Options) ->
     mochiweb_socket_server:start_link(parse_options(Options)).


### PR DESCRIPTION
support start a server listen on an opened socket, so we can start multiple server on one socket to get a better performance.

I also add a example named multi_server.erl, when this example is running in the erlang shell, use `curl 'http://localhost:port'` command serveral times will show the request is handle by different server.
