### PR TITLE
Properly receive websockets frames when using ssl

### DIFF
--- a/src/mochiweb_websocket.erl
+++ b/src/mochiweb_websocket.erl
@@ -56,6 +56,18 @@ request(Socket, Body, State, WsVersion, ReplyChannel) ->
                     NewState = call_body(Body, Payload, State, ReplyChannel),
                     loop(Socket, Body, NewState, WsVersion, ReplyChannel)
             end;
+        {ssl, _, WsFrames} ->
+            case parse_frames(WsVersion, WsFrames, Socket) of
+                close ->
+                    mochiweb_socket:close(Socket),
+                    exit(normal);
+                error ->
+                    mochiweb_socket:close(Socket),
+                    exit(normal);
+                Payload ->
+                    NewState = call_body(Body, Payload, State, ReplyChannel),
+                    loop(Socket, Body, NewState, WsVersion, ReplyChannel)
+            end;
         _ ->
             mochiweb_socket:close(Socket),
             exit(normal)


### PR DESCRIPTION
It seems that websocket packets sent from the client to the mochiweb server are not received when using SSL websockets. I've added some code that seems to fix it...