### PR TITLE
Accept range end position which exceededs the resource size

### DIFF
--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -137,8 +137,6 @@ after_response(Body, Req) ->
             ?MODULE:loop(Socket, Body)
     end.
 
-parse_range_request("bytes=0-") ->
-    undefined;
 parse_range_request(RawRange) when is_list(RawRange) ->
     try
         "bytes=" ++ RangeString = RawRange,
@@ -169,7 +167,7 @@ range_skip_length(Spec, Size) ->
             {R, Size - R};
         {_OutOfRange, none} ->
             invalid_range;
-        {Start, End} when 0 =< Start, Start =< End, End < Size ->
+        {Start, End} when 0 =< Start, Start < Size, Start =< End ->
             {Start, End - Start + 1};
         {_OutOfRange, _End} ->
             invalid_range
@@ -188,7 +186,7 @@ range_test() ->
     ?assertEqual([{none, 20}], parse_range_request("bytes=-20")),
 
     %% trivial single range
-    ?assertEqual(undefined, parse_range_request("bytes=0-")),
+    ?assertEqual([{0, none}], parse_range_request("bytes=0-")),
 
     %% invalid, single ranges
     ?assertEqual(fail, parse_range_request("")),
@@ -222,6 +220,7 @@ range_skip_length_test() ->
     ?assertEqual({BodySize, 0}, range_skip_length({none, 0}, BodySize)),
     ?assertEqual({0, BodySize}, range_skip_length({none, BodySize}, BodySize)),
     ?assertEqual({0, BodySize}, range_skip_length({0, none}, BodySize)),
+    ?assertEqual({0, BodySize}, range_skip_length({0, BodySize + 1}, BodySize)),
     BodySizeLess1 = BodySize - 1,
     ?assertEqual({BodySizeLess1, 1},
                  range_skip_length({BodySize - 1, none}, BodySize)),
@@ -245,6 +244,8 @@ range_skip_length_test() ->
                  range_skip_length({-1, none}, BodySize)),
     ?assertEqual(invalid_range,
                  range_skip_length({BodySize, none}, BodySize)),
+    ?assertEqual(invalid_range,
+                 range_skip_length({BodySize + 1, BodySize + 5}, BodySize)),
     ok.
 
 -endif.


### PR DESCRIPTION
RFC 2616 14.35.1 Byte Ranges

    If the last-byte-pos value is absent, or if the value is greater than
    or equal to the current length of the entity-body, last-byte-pos is
    taken to be equal to one less than the current length of the entity-
    body in bytes.

This work is originally done by @shino and feedback of https://github.com/basho/mochiweb/pull/17 and https://github.com/basho/mochiweb/pull/7 .