### PR TITLE
Fixed up crash when setting options to closed sockets.

### DIFF
--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -75,7 +75,13 @@ loop(Socket, Opts, Body) ->
     request(Socket, Opts, Body).
 
 request(Socket, Opts, Body) ->
-    ok = mochiweb_socket:setopts(Socket, [{active, once}]),
+    case  mochiweb_socket:setopts(Socket, [{active, once}]) of
+		{error,_} ->
+			mochiweb_socket:close(Socket),
+			exit(normal);
+		ok -> 
+			ok
+	end,
     receive
         {Protocol, _, {http_request, Method, Path, Version}} when Protocol == http orelse Protocol == ssl ->
             ok = mochiweb_socket:setopts(Socket, [{packet, httph}]),


### PR DESCRIPTION
Setting options to closed sockets will crash the Erlang process. This actually happens often as sockets can close at any time. We observed this in our servers that identifies a bad match, where it expects the ok but gets {error, closed}. 

The changes in this commit allows the process to exit gracefully instead.