### PR TITLE
performance: cache date

### DIFF
--- a/src/mochiweb_clock.erl
+++ b/src/mochiweb_clock.erl
@@ -58,7 +58,7 @@ rfc1123() ->
         [{rfc1123, Date}] ->
             Date;
         [] ->
-            <<"">>
+            ""
     end.
 
 %% gen_server.

--- a/src/mochiweb_clock.erl
+++ b/src/mochiweb_clock.erl
@@ -1,0 +1,101 @@
+%% Copyright (c) 2011-2014, Loïc Hoguin <essen@ninenines.eu>
+%% Copyright (c) 2015, Robert Kowalski <rok@kowalski.gd>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+%% While a gen_server process runs in the background to update
+%% the cache of formatted dates every second, all API calls are
+%% local and directly read from the ETS cache table, providing
+%% fast time and date computations.
+
+-module(mochiweb_clock).
+
+-behaviour(gen_server).
+
+%% API.
+-export([start_link/0]).
+-export([start/0]).
+-export([stop/0]).
+-export([rfc1123/0]).
+
+%% gen_server.
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+-export([terminate/2]).
+-export([code_change/3]).
+
+-record(state, {}).
+
+%% API.
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec start() -> {ok, pid()}.
+start() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec stop() -> stopped.
+stop() ->
+    gen_server:call(?MODULE, stop).
+
+-spec rfc1123() -> string().
+rfc1123() ->
+    case ets:lookup(lala, rfc1123) of
+        [{rfc1123, Date}] ->
+            Date;
+        [] ->
+            <<"">>
+    end.
+
+%% gen_server.
+
+-spec init([]) -> {ok, #state{}}.
+init([]) ->
+    lala = ets:new(lala, [named_table, protected]),
+    handle_info(update_date, #state{}),
+    timer:send_interval(1000, update_date),
+    {ok, #state{}}.
+
+-type from() :: {pid(), term()}.
+-spec handle_call
+    (stop, from(), State) -> {stop, normal, stopped, State}
+    when State::#state{}.
+handle_call(stop, _From, State) ->
+    {stop, normal, stopped, State};
+handle_call(_Request, _From, State) ->
+    {reply, ignored, State}.
+
+-spec handle_cast(_, State) -> {noreply, State} when State::#state{}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(any(), State) -> {noreply, State} when State::#state{}.
+handle_info(update_date, State) ->
+    Date = httpd_util:rfc1123_date(),
+    ets:insert(lala, {rfc1123, Date}),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(_, _) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+-spec code_change(_, State, _) -> {ok, State} when State::#state{}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+

--- a/src/mochiweb_clock.erl
+++ b/src/mochiweb_clock.erl
@@ -46,7 +46,7 @@ start_link() ->
 
 -spec start() -> {ok, pid()}.
 start() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
 
 -spec stop() -> stopped.
 stop() ->

--- a/src/mochiweb_clock.erl
+++ b/src/mochiweb_clock.erl
@@ -54,7 +54,7 @@ stop() ->
 
 -spec rfc1123() -> string().
 rfc1123() ->
-    case ets:lookup(lala, rfc1123) of
+    case ets:lookup(?MODULE, rfc1123) of
         [{rfc1123, Date}] ->
             Date;
         [] ->
@@ -65,7 +65,7 @@ rfc1123() ->
 
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-    lala = ets:new(lala, [named_table, protected]),
+    ?MODULE = ets:new(?MODULE, [named_table, protected]),
     handle_info(update_date, #state{}),
     timer:send_interval(1000, update_date),
     {ok, #state{}}.
@@ -86,7 +86,7 @@ handle_cast(_Msg, State) ->
 -spec handle_info(any(), State) -> {noreply, State} when State::#state{}.
 handle_info(update_date, State) ->
     Date = httpd_util:rfc1123_date(),
-    ets:insert(lala, {rfc1123, Date}),
+    ets:insert(?MODULE, {rfc1123, Date}),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/src/mochiweb_clock.erl
+++ b/src/mochiweb_clock.erl
@@ -65,7 +65,7 @@ rfc1123() ->
 
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-    ?MODULE = ets:new(?MODULE, [named_table, protected]),
+    ?MODULE = ets:new(?MODULE, [named_table, protected, {read_concurrency, true}]),
     handle_info(update_date, #state{}),
     timer:send_interval(1000, update_date),
     {ok, #state{}}.

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -48,11 +48,9 @@ parse_options(Options) ->
     mochilists:set_defaults(?DEFAULTS, Options1).
 
 stop() ->
-    mochiweb_clock:stop(),
     mochiweb_socket_server:stop(?MODULE).
 
 stop(Name) ->
-    mochiweb_clock:stop(),
     mochiweb_socket_server:stop(Name).
 
 %% @spec start(Options) -> ServerRet

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -48,9 +48,11 @@ parse_options(Options) ->
     mochilists:set_defaults(?DEFAULTS, Options1).
 
 stop() ->
+    mochiweb_clock:stop(),
     mochiweb_socket_server:stop(?MODULE).
 
 stop(Name) ->
+    mochiweb_clock:stop(),
     mochiweb_socket_server:stop(Name).
 
 %% @spec start(Options) -> ServerRet
@@ -65,9 +67,11 @@ stop(Name) ->
 %%      The proplist is as follows: [{name, Name}, {port, Port}, {active_sockets, ActiveSockets}, {timing, Timing}].
 %% @end
 start(Options) ->
+    {ok, _Pid} = mochiweb_clock:start(),
     mochiweb_socket_server:start(parse_options(Options)).
 
 start_link(Options) ->
+    {ok, _Pid} = mochiweb_clock:start_link(),
     mochiweb_socket_server:start_link(parse_options(Options)).
 
 loop(Socket, Opts, Body) ->

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -76,7 +76,7 @@ ensure_started(M) ->
     case M:start() of
         {ok, _Pid} ->
             ok;
-        {error, {already_started, _PID}} ->
+        {error, {already_started, _Pid}} ->
             ok
     end.
 

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -73,7 +73,7 @@ start_link(Options) ->
     mochiweb_socket_server:start_link(parse_options(Options)).
 
 ensure_started(M) ->
-    case erlang:apply(M, start, []) of
+    case M:start() of
         {ok, _Pid} ->
             ok;
         {error, {already_started, _PID}} ->

--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -67,12 +67,20 @@ stop(Name) ->
 %%      The proplist is as follows: [{name, Name}, {port, Port}, {active_sockets, ActiveSockets}, {timing, Timing}].
 %% @end
 start(Options) ->
-    {ok, _Pid} = mochiweb_clock:start(),
+    ok = ensure_started(mochiweb_clock),
     mochiweb_socket_server:start(parse_options(Options)).
 
 start_link(Options) ->
-    {ok, _Pid} = mochiweb_clock:start_link(),
+    ok = ensure_started(mochiweb_clock),
     mochiweb_socket_server:start_link(parse_options(Options)).
+
+ensure_started(M) ->
+    case erlang:apply(M, start, []) of
+        {ok, _Pid} ->
+            ok;
+        {error, {already_started, _PID}} ->
+            ok
+    end.
 
 loop(Socket, Opts, Body) ->
     ok = mochiweb_socket:exit_if_closed(mochiweb_socket:setopts(Socket, [{packet, http}])),

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -691,7 +691,7 @@ maybe_serve_file(File, ExtraHeaders, {?MODULE, [_Socket, _Opts, _Method, _RawPat
 
 server_headers() ->
     [{"Server", "MochiWeb/1.0 (" ++ ?QUIP ++ ")"},
-     {"Date", httpd_util:rfc1123_date()}].
+     {"Date", mochiweb_clock:rfc1123()}].
 
 make_code(X) when is_integer(X) ->
     [integer_to_list(X), [" " | httpd_util:reason_phrase(X)]];


### PR DESCRIPTION
Hi and thanks for creating mochiweb!

We use it in CouchDB and I noticed that formatting the date for the header is a performance issue for us.

[Here is the flamegraph that I created for requesting a document](http://robert-kowalski.de/assets/data/2015-06-01-erlang-perf-2/flame--second--unpatched.svg)

[The flamegraph for a simple hello_world handler in mochiweb looks like this](http://robert-kowalski.de/assets/data/erlang-perf/mochi-flame-patched.svg)

For CouchDB the performance [improvement is 2%](https://github.com/apache/couchdb-mochiweb/pull/1) but with a very simple hello world app it was 14% given enough concurrent requests. 

as the formatting of the date for each request is quite expensive
we cache it in an ets table now.

heavily inspired by cowboy, but does not use binaries and uses
still httpd_util:rfc1183 internally.