### PR TITLE
Bugfix: <3 is not a valid html tag start, it's an emoji.

### DIFF
--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -54,6 +54,8 @@
 
 -define(IS_WHITESPACE(C),
         (C =:= $\s orelse C =:= $\t orelse C =:= $\r orelse C =:= $\n)).
+-define(IS_LETTER(C),
+        ((C >= $A andalso C =< $Z) orelse (C >= $a andalso C =< $z))).
 -define(IS_LITERAL_SAFE(C),
         ((C >= $A andalso C =< $Z) orelse (C >= $a andalso C =< $z)
          orelse (C >= $0 andalso C =< $9))).
@@ -349,7 +351,7 @@ tokenize(B, S=#decoder{offset=O}) ->
             {S2, _} = find_gt(B, S1),
             {{end_tag, Tag}, S2};
         <<_:O/binary, "<", C, _/binary>>
-                when ?IS_WHITESPACE(C); not ?IS_LITERAL_SAFE(C) ->
+                when ?IS_WHITESPACE(C); not ?IS_LETTER(C) ->
             %% This isn't really strict HTML
             {{data, Data, _Whitespace}, S1} = tokenize_data(B, ?INC_COL(S)),
             {{data, <<$<, Data/binary>>, false}, S1};

--- a/test/mochiweb_html_tests.erl
+++ b/test/mochiweb_html_tests.erl
@@ -601,3 +601,10 @@ implicit_html_test() ->
         [{<<"head">>, [], []},
          {<<"body">>, [], []}]},
        mochiweb_html:parse("<!doctype html><head></head><body></body>")).
+
+no_letter_no_tag_test() ->
+    ?assertEqual(
+       {<<"html">>,[],
+         [{<<"body">>,[],[<<"<3><!><*><<>>">>,{<<"body">>,[],[]}]}]},
+       mochiweb_html:parse(<<"<html><body><3><!><*><<>><body></html>">>)
+      ).


### PR DESCRIPTION
Browsers treat <3 as text, not as a start of html tag.