### PR TITLE
Fix otp19 deprecation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 % -*- mode: erlang -*-
 {erl_opts, [debug_info,
             {platform_define, "R15", 'gen_tcp_r15b_workaround'},
-            {platform_define, "(R14|R15|R16B-)", 'crypto_compatibility'}]}.
+            {platform_define, "(R14|R15|R16B-)", 'crypto_compatibility'},
+            {platform_define, "(R14|R15|R16B|17)", 'rand_mod_unavailable'}]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {dialyzer_opts, [{warnings, [no_return,

--- a/src/mochiweb_multipart.erl
+++ b/src/mochiweb_multipart.erl
@@ -56,7 +56,7 @@ parts_to_body([{Start, End, Body}], ContentType, Size) ->
     {HeaderList, Body};
 parts_to_body(BodyList, ContentType, Size) when is_list(BodyList) ->
     parts_to_multipart_body(BodyList, ContentType, Size,
-                            mochihex:to_hex(crypto:rand_bytes(8))).
+                            mochihex:to_hex(crypto:strong_rand_bytes(8))).
 
 %% @spec parts_to_multipart_body([bodypart()], ContentType::string(),
 %%                               Size::integer(), Boundary::string()) ->

--- a/src/mochiweb_session.erl
+++ b/src/mochiweb_session.erl
@@ -122,7 +122,7 @@ ensure_binary(L) when is_list(L) ->
 -ifdef(crypto_compatibility).
 -spec encrypt_data(binary(), binary()) -> binary().
 encrypt_data(Data, Key) ->
-    IV = crypto:rand_bytes(16),
+    IV = crypto:strong_rand_bytes(16),
     Crypt = crypto:aes_cfb_128_encrypt(Key, IV, Data),
     <<IV/binary, Crypt/binary>>.
 
@@ -141,7 +141,7 @@ gen_hmac(ExpirationTime, Data, SessionKey, Key) ->
 -else.
 -spec encrypt_data(binary(), binary()) -> binary().
 encrypt_data(Data, Key) ->
-    IV = crypto:rand_bytes(16),
+    IV = crypto:strong_rand_bytes(16),
     Crypt = crypto:block_encrypt(aes_cfb128, Key, IV, Data),
     <<IV/binary, Crypt/binary>>.
 

--- a/test/mochiweb_base64url_tests.erl
+++ b/test/mochiweb_base64url_tests.erl
@@ -9,10 +9,15 @@ id(X) ->
        X,
        mochiweb_base64url:decode(
          binary_to_list(mochiweb_base64url:encode(binary_to_list(X))))).
-
+-ifdef(rand_mod_unavailable).
 random_binary(Short,Long) ->
     << <<(random:uniform(256) - 1)>>
      || _ <- lists:seq(1, Short + random:uniform(1 + Long - Short) - 1) >>.
+-else.
+random_binary(Short,Long) ->
+    << <<(rand:uniform(256) - 1)>>
+     || _ <- lists:seq(1, Short + rand:uniform(1 + Long - Short) - 1) >>.
+-endif.
 
 empty_test() ->
     id(<<>>).

--- a/test/mochiweb_tests.erl
+++ b/test/mochiweb_tests.erl
@@ -155,7 +155,7 @@ do_POST(Transport, Size, Times) ->
                 end,
     TestReqs = [begin
                     Path = "/stuff/" ++ integer_to_list(N),
-                    Body = crypto:rand_bytes(Size),
+                    Body = crypto:strong_rand_bytes(Size),
                     #treq{path=Path, body=Body, xreply=Body}
                 end || N <- lists:seq(1, Times)],
     ClientFun = new_client_fun('POST', TestReqs),


### PR DESCRIPTION
Since OTP 19 random has been deprecated in favour of rand.

Since OTP 19 crypto:rand_bytes/1 has been deprecated in favour of crypto:strong_rand_bytes/1.

See [otp_src_19.0.readme](http://erlang.org/download/otp_src_19.0.readme).