### PR TITLE
adding missing RFC1918 addresss space to the allowed x-forwarded-for header

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -119,6 +119,21 @@ get(peer, {?MODULE, [Socket, _Opts, _Method, _RawPath, _Version, _Headers]}=THIS
                 Hosts ->
                     string:strip(lists:last(string:tokens(Hosts, ",")))
             end;
+        %% Copied this syntax from webmachine contributor Steve Vinoski
+        {ok, {Addr={172, Second, _, _}, _Port}} when (Second > 15) andalso (Second < 32) ->
+            case get_header_value("x-forwarded-for", THIS) of
+                undefined ->
+                    inet_parse:ntoa(Addr);
+                Hosts ->
+                    string:strip(lists:last(string:tokens(Hosts, ",")))
+            end;
+        {ok, {Addr={192, 168, _, _}, _Port}} ->
+            case get_header_value("x-forwarded-for", THIS) of
+                undefined ->
+                    inet_parse:ntoa(Addr);
+                Hosts ->
+                    string:strip(lists:last(string:tokens(Hosts, ",")))
+            end;
         {ok, {{127, 0, 0, 1}, _Port}} ->
             case get_header_value("x-forwarded-for", THIS) of
                 undefined ->


### PR DESCRIPTION
This will ensure users of 192.168/16 and 172.16/12 internal networks also allow the use of X-Forwarded-For