### PR TITLE
Handle missing closing tag for all empty elements

### DIFF
--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -464,16 +464,21 @@ destack([{Tag, Attrs, Acc}]) ->
 destack([{T1, A1, Acc1}, {T0, A0, Acc0} | Rest]) ->
     destack([{T0, A0, [{T1, A1, lists:reverse(Acc1)} | Acc0]} | Rest]).
 
+is_singleton(<<"area">>) -> true;
+is_singleton(<<"base">>) -> true;
 is_singleton(<<"br">>) -> true;
+is_singleton(<<"col">>) -> true;
+is_singleton(<<"embed">>) -> true;
 is_singleton(<<"hr">>) -> true;
 is_singleton(<<"img">>) -> true;
 is_singleton(<<"input">>) -> true;
-is_singleton(<<"base">>) -> true;
-is_singleton(<<"meta">>) -> true;
+is_singleton(<<"keygen">>) -> true;
 is_singleton(<<"link">>) -> true;
-is_singleton(<<"area">>) -> true;
+is_singleton(<<"meta">>) -> true;
 is_singleton(<<"param">>) -> true;
-is_singleton(<<"col">>) -> true;
+is_singleton(<<"source">>) -> true;
+is_singleton(<<"track">>) -> true;
+is_singleton(<<"wbr">>) -> true;
 is_singleton(_) -> false.
 
 tokenize_data(B, S=#decoder{offset=O}) ->

--- a/test/mochiweb_html_tests.erl
+++ b/test/mochiweb_html_tests.erl
@@ -428,6 +428,52 @@ dumb_br_test() ->
        {<<"div">>,[],[{<<"br">>, [], []}, {<<"br">>, [], []}, <<"z">>]},
        mochiweb_html:parse("<div><br><br>z</br></br></div>")).
 
+empty_elements_test() ->
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"area">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<area>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"base">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<base>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"br">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<br>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"col">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<col>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"embed">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<embed>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"hr">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<hr>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"img">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<img>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"input">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<input>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"keygen">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<keygen>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"link">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<link>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"meta">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<meta>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"param">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<param>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"source">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<source>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"track">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<track>z</div>")),
+    ?assertEqual(
+       {<<"div">>,[],[<<"a">>,{<<"wbr">>,[],[]},<<"z">>]},
+       mochiweb_html:parse("<div>a<wbr>z</div>")).
 
 php_test() ->
     %% http://code.google.com/p/mochiweb/issues/detail?id=71


### PR DESCRIPTION
I got the full list of elements from:

  https://developer.mozilla.org/en-US/docs/Glossary/empty_element