### PR TITLE
Add the Shared Address Space address range

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -127,6 +127,14 @@ get(peer, {?MODULE, [Socket, _Opts, _Method, _RawPath, _Version, _Headers]}=THIS
                 Hosts ->
                     string:strip(lists:last(string:tokens(Hosts, ",")))
             end;
+        %% According to RFC 1918, contributor Gerald Xv
+        {ok, {Addr={100, Second, _, _}, _Port}} when (Second > 63) andalso (Second < 128) ->
+            case get_header_value("x-forwarded-for", THIS) of
+                undefined ->
+                    inet_parse:ntoa(Addr);
+                Hosts ->
+                    string:strip(lists:last(string:tokens(Hosts, ",")))
+            end;
         {ok, {Addr={192, 168, _, _}, _Port}} ->
             case get_header_value("x-forwarded-for", THIS) of
                 undefined ->

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -127,7 +127,7 @@ get(peer, {?MODULE, [Socket, _Opts, _Method, _RawPath, _Version, _Headers]}=THIS
                 Hosts ->
                     string:strip(lists:last(string:tokens(Hosts, ",")))
             end;
-        %% According to RFC 1918, contributor Gerald Xv
+        %% According to RFC 6598, contributor Gerald Xv
         {ok, {Addr={100, Second, _, _}, _Port}} when (Second > 63) andalso (Second < 128) ->
             case get_header_value("x-forwarded-for", THIS) of
                 undefined ->


### PR DESCRIPTION
We encountered such an example, the cloud host platform used to retain IP as the internal IP.