### PR TITLE
add tuple_calls compiler flag for erlang 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 % -*- mode: erlang -*-
 {erl_opts, [debug_info,
+            tuple_calls,
             {platform_define, "^R15", 'gen_tcp_r15b_workaround'},
             {platform_define, "^(R14|R15|R16B-)", 'crypto_compatibility'},
             {platform_define, "^(R14|R15|R16B|17)", 'rand_mod_unavailable'},


### PR DESCRIPTION
From http://www.erlang.org/news/123 :
* "Tuple calls" have been removed from the run-time system.

http://erlang.org/download/otp_src_21.0.readme
* OTP-14497 

               For legacy code that need to use parameterized modules
               or tuple calls for some other reason, there is a new
               compiler option called tuple_calls. When this option is
               given, the compiler will generate extra code that
               emulates the old behavior for calls where the module is
               a variable.

Without this patch, mochiweb crashes when tuple calls are used