### PR TITLE
Don't crash if a socket is closed server side

### DIFF
--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -144,5 +144,7 @@ type(_) ->
 
 exit_if_closed({error, closed}) ->
     exit(normal);
+exit_if_closed({error, einval}) ->
+    exit(normal);
 exit_if_closed(Res) ->
     Res.


### PR DESCRIPTION
If, for some reason, the programmer decides to close the socket server side,
the return value for setopts on the socket is `{error, einval}` rather than
`{error, closed}`. This change accepts that and suppresses the error message
generated by a badmatch at https://github.com/mochi/mochiweb/blob/master/src/mochiweb_http.erl#L88