### PR TITLE
Use dist: trusty for Travis builds with old Erlang releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ otp_release:
   - 21.0
   - 20.0
   - 19.0
-  - 18.3
-  - 17.5
-  - R16B03-1
-  - R15B03
-before_script:
-  - kerl list installations
+matrix:
+  include:
+  - otp_release: 18.3
+    dist: trusty
+  - otp_release: 17.5
+    dist: trusty
+  - otp_release: R16B03-1
+    dist: trusty
+  - otp_release: R15B03
+    dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ otp_release:
   - 17.5
   - R16B03-1
   - R15B03
+before_script:
+  - kerl list installations


### PR DESCRIPTION
Old releases do not have precompiled binaries available for xenial, which is now the default dist for Travis.