### PR TITLE
Support multiple values in x-forwarded-for and internet proxies

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -164,43 +164,13 @@ get(peer,
     {?MODULE,
      [Socket, _Opts, _Method, _RawPath, _Version,
       _Headers]} =
-	THIS) ->
+    THIS) ->
     case mochiweb_socket:peername(Socket) of
-      {ok, {Addr = {10, _, _, _}, _Port}} ->
-	  case get_header_value("x-forwarded-for", THIS) of
-	    undefined -> inet_parse:ntoa(Addr);
-	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
-	  end;
-      %% Copied this syntax from webmachine contributor Steve Vinoski
-      {ok, {Addr = {172, Second, _, _}, _Port}}
-	  when Second > 15 andalso Second < 32 ->
-	  case get_header_value("x-forwarded-for", THIS) of
-	    undefined -> inet_parse:ntoa(Addr);
-	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
-	  end;
-      %% According to RFC 6598, contributor Gerald Xv
-      {ok, {Addr = {100, Second, _, _}, _Port}}
-	  when Second > 63 andalso Second < 128 ->
-	  case get_header_value("x-forwarded-for", THIS) of
-	    undefined -> inet_parse:ntoa(Addr);
-	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
-	  end;
-      {ok, {Addr = {192, 168, _, _}, _Port}} ->
-	  case get_header_value("x-forwarded-for", THIS) of
-	    undefined -> inet_parse:ntoa(Addr);
-	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
-	  end;
-      {ok, {{127, 0, 0, 1}, _Port}} ->
-	  case get_header_value("x-forwarded-for", THIS) of
-	    undefined -> "127.0.0.1";
-	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
-	  end;
-      {ok, {Addr, _Port}} -> inet_parse:ntoa(Addr);
+      {ok, {Addr, _Port}} ->
+      case get_header_value("x-forwarded-for", THIS) of
+        undefined -> inet_parse:ntoa(Addr);
+        Hosts -> string:strip(hd(string:tokens(Hosts, ",")))
+      end;
       {error, enotconn} -> exit(normal)
     end;
 get(path,


### PR DESCRIPTION
```
X-Forwarded-For:client, proxy1, proxy2
```
X-Forwarded-For may contain multiple values,
So we need to replace `lists:last` to `hd` in order to get client ip,
And whether it's from intranet or not, so remove 192.168 or 100 expressions.