### PR TITLE
Add unquote_path/1 for separate + encoding

### DIFF
--- a/test/mochiweb_util_tests.erl
+++ b/test/mochiweb_util_tests.erl
@@ -1,0 +1,17 @@
+-module(mochiweb_util_tests).
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+unquote_test() ->
+    Str = "/test/path/dwabble%20wibble+quux?qs=2",
+    ?assertEqual("/test/path/dwabble wibble quux?qs=2",
+        mochiweb_util:unquote(Str)).
+
+unquote_path_test() ->
+    Str = "/test/path/dwabble%20wibble+quux?qs=2",
+    ?assertEqual("/test/path/dwabble wibble+quux?qs=2",
+        mochiweb_util:unquote_path(Str)).
+
+-endif.


### PR DESCRIPTION
Currently, `+` is always encoded into space. This PR adds a separate `unquote_path/1` function that does not encode `+` into space. See [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#appendix-A), specifically:
```
pchar   = unreserved / pct-encoded / sub-delims / ":" / "@"` 
sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
```