### PR TITLE
Use {shutdown, Error} when terminating connection processes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+New version
+
+* Crashing client processes now exit with reason
+  `{shutdown, Error}`. This ensures processes
+  linked to the connection process are also
+  cleaned up. If exit `normal` was caught in a
+  request loop callback, for example in a
+  `try ... catch exit:normal ...` expression,
+  that expression might have to be updated to
+  handle the `{shutdown, Error}` error reason.
+  https://github.com/mochi/mochiweb/pull/238
+
 Version 2.22.0 released 2021-08-23
 
 * Renamed master branch to main

--- a/src/mochiweb_acceptor.erl
+++ b/src/mochiweb_acceptor.erl
@@ -55,7 +55,7 @@ init(Server, Listen, Loop, Opts) ->
       {error, Err}
 	  when Err =:= closed orelse
 		 Err =:= esslaccept orelse Err =:= timeout ->
-	  exit(normal);
+	  exit({shutdown, Err});
       Other ->
 	  %% Mitigate out of file descriptor scenario by sleeping for a
 	  %% short time to slow error rate

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -174,9 +174,9 @@ type({ssl, _}) ->
 type(_) ->
     plain.
 
-exit_if_closed({error, closed}) ->
-    exit(normal);
-exit_if_closed({error, einval}) ->
-    exit(normal);
+exit_if_closed({error, closed = Error}) ->
+    exit({shutdown, Error});
+exit_if_closed({error, einval = Error}) ->
+    exit({shutdown, Error});
 exit_if_closed(Res) ->
     Res.


### PR DESCRIPTION
Previously they exited `normal`, which helped avoid error log spam. However, that also meant any linked helper processes would not exit when the main connection process had been terminated.

To automatically clean up any linked processes, and continue avoiding generating error logs, we can use `{shutdown, Error}` as the exit reason. That error, along with `shutdown` atom, are special exit reasons which are considered `normal` for proc_lib processes and will not generate error logs [1].

Another benefit is having more specific exit reasons (send error, recv error, etc.), which may help with debugging.

[1] https://www.erlang.org/docs/24/man/proc_lib.html#description