### PR TITLE
Handle {shutdown, Error} when recycling acceptor pids

### DIFF
--- a/src/mochiweb_socket_server.erl
+++ b/src/mochiweb_socket_server.erl
@@ -373,6 +373,8 @@ handle_info(Msg, State) when ?is_old_state(State) ->
     handle_info(Msg, upgrade_state(State));
 handle_info({'EXIT', Pid, normal}, State) ->
     {noreply, recycle_acceptor(Pid, State)};
+handle_info({'EXIT', Pid, {shutdown, _Error}}, State) ->
+    {noreply, recycle_acceptor(Pid, State)};
 handle_info({'EXIT', Pid, Reason},
             State=#mochiweb_socket_server{acceptor_pool=Pool}) ->
     case sets:is_element(Pid, Pool) of


### PR DESCRIPTION
After https://github.com/mochi/mochiweb/pull/238 acceptor processes would exit with `{shutdown, Error}` on timeouts and other errors which were `normal` before.