### PR TITLE
mochinum:digits/1: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/mochinum.erl
+++ b/src/mochinum.erl
@@ -44,7 +44,7 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
-digits(0.0) ->
+digits(Float) when Float == 0.0 ->
     "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),
@@ -287,6 +287,8 @@ digits_test() ->
                  digits(0)),
     ?assertEqual("0.0",
                  digits(0.0)),
+    ?assertEqual("0.0",
+                 digits(-0.0)),
     ?assertEqual("1.0",
                  digits(1.0)),
     ?assertEqual("-1.0",


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in mochiweb results in:

src/mochinum.erl:47:8: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from a match to a numerical comparison.