### PR TITLE
Add OTP 28 to CI and fix crypto:start() deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         otp:
+          - "28"
           - "27"
           - "26"
           - "25"

--- a/src/mochitemp.erl
+++ b/src/mochitemp.erl
@@ -195,7 +195,7 @@ gettempdir_cwd_test() ->
     ok.
 
 rngchars_test() ->
-    crypto:start(),
+    application:start(crypto),
     ?assertEqual(
        "",
        rngchars(0)),
@@ -217,7 +217,7 @@ rngchar_test() ->
     ok.
 
 mkdtemp_n_failonce_test() ->
-    crypto:start(),
+    application:start(crypto),
     D = mkdtemp(),
     Path = filename:join([D, "testdir"]),
     %% Toggle the existence of a dir so that it fails
@@ -264,7 +264,7 @@ make_dir_fail_test() ->
     ok.
 
 mkdtemp_test() ->
-    crypto:start(),
+    application:start(crypto),
     D = mkdtemp(),
     ?assertEqual(
        true,
@@ -275,7 +275,7 @@ mkdtemp_test() ->
     ok.
 
 rmtempdir_test() ->
-    crypto:start(),
+    application:start(crypto),
     D1 = mkdtemp(),
     ?assertEqual(
        true,

--- a/src/mochiweb_session.erl
+++ b/src/mochiweb_session.erl
@@ -168,7 +168,7 @@ generate_check_session_cookie_test_() ->
      fun generate_check_session_cookie/1}.
 
 setup_server_key() ->
-    crypto:start(),
+    application:start(crypto),
     ["adfasdfasfs",30000].
 
 generate_check_session_cookie([ServerKey, TS]) ->


### PR DESCRIPTION
As separate commits:
  - Use OTP 28 in CI
  - Fix `crypto:start()` deprecation warning (should work as far back as [OTP 18](https://www.erlang.org/docs/18/man/crypto#start-0))