### PR TITLE
Add gzip and zstd chunked response compression

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -466,11 +466,12 @@ format_response_header({Code, ResponseHeaders, Length},
 					Length, HResponse),
     format_response_header({Code, HResponse1}, THIS).
 
-%% @spec respond({integer(), ioheaders(), iodata() | chunked | {file, IoDevice}}, request()) -> response()
+%% @spec respond({integer(), ioheaders(), iodata() | chunked | {chunked, {Codec, integer()}} | {file, IoDevice}}, request()) -> response()
 %% @doc Start the HTTP response with start_response, and send Body to the
 %%      client (if the get(method) /= 'HEAD'). The Content-Length header
 %%      will be set by the Body length, and the server will insert header
-%%      defaults.
+%%      defaults. A {chunked, {Codec = gzip|zstd, Level}} body starts a chunked
+%%      response with chunks compressed by write_chunk/2
 respond({Code, ResponseHeaders, {file, IoDevice}},
 	{?MODULE,
 	 [_Socket, _Opts, Method, _RawPath, _Version,
@@ -514,6 +515,24 @@ respond({Code, ResponseHeaders, chunked},
 		       HResponse
 		 end,
     start_response({Code, HResponse1}, THIS);
+respond({Code, ResponseHeaders, {chunked, {Codec, Level}}},
+	{?MODULE,
+	 [_Socket, _Opts, Method, _RawPath, _Version, _Headers]} =
+	    THIS)
+    when Codec =:= gzip; Codec =:= zstd ->
+    %% ResponseHeaders has the content-encoding already so unsupported
+    %% codecs (for ex. zstd on OTP < 29) shouldn't produce a response for
+    %% encoding the body doesn't have
+    case lists:member(Codec, mochiweb_response:supported_encoders()) of
+      true -> ok;
+      false -> erlang:error({unsupported_encoder, Codec})
+    end,
+    Response = respond({Code, ResponseHeaders, chunked}, THIS),
+    case Method of
+      %% For HEAD we don't have a body so we don't compress anything
+      'HEAD' -> Response;
+      _ -> mochiweb_response:encoder(Codec, Level, Response)
+    end;
 respond({Code, ResponseHeaders, Body},
 	{?MODULE,
 	 [_Socket, _Opts, Method, _RawPath, _Version,

--- a/src/mochiweb_response.erl
+++ b/src/mochiweb_response.erl
@@ -27,44 +27,74 @@
 
 -define(QUIP, "Any of you quaids got a smint?").
 
--export([dump/1, get/2, get_header_value/2, new/3]).
+-export([dump/1, get/2, get_header_value/2, new/3, new/4,
+	 encoder/3, supported_encoders/0]).
 
 -export([send/2, write_chunk/2]).
 
 %% @type response(). A mochiweb_response parameterized module instance.
+%% @type encoding(). gzip | zstd
 
 %% @spec new(Request, Code, Headers) -> response()
 %% @doc Create a new mochiweb_response instance.
 new(Request, Code, Headers) ->
     {?MODULE, [Request, Code, Headers]}.
 
+%% @spec new(Request, Code, Headers, {encoding(), Context}) -> response()
+%% @doc Create a new mochiweb_response where write_chunk/2 will use a given
+%%      encoder context
+new(Request, Code, Headers, {Codec, _} = Encoder)
+    when Codec =:= gzip; Codec =:= zstd ->
+    {?MODULE, [Request, Code, Headers, Encoder]}.
+
+%% @spec supported_encoders() -> [encoding()]
+%% @doc The codecs encoder/3 supports in this build. zstd requires the
+%%      zstd module with flush support and that's in OTP 29+ only.
+supported_encoders() ->
+    [gzip] ++ zstd_supported().
+
+%% @spec encoder(encoding(), integer(), response()) -> response()
+%% @doc Return a response so that its write_chunk/2 compresses each chunk with
+%%      the given codec. Every chunk is flushed so bytes are written
+%%      out immediately. Empty chunk that finishes a chunked response will end the
+%%      compression stream. The caller should include the matching content-encoding
+%%      response header.
+encoder(gzip, Level, {?MODULE, [Request, Code, Headers]}) ->
+    Z = zlib:open(),
+    %% 16 + 15 is gzip framing with the maximum window size
+    %% (from zlib.erl gzip/1)
+    ok = zlib:deflateInit(Z, Level, deflated, 16 + 15, 8, default),
+    new(Request, Code, Headers, {gzip, Z});
+encoder(zstd, Level, {?MODULE, [Request, Code, Headers]}) ->
+    new(Request, Code, Headers, {zstd, zstd_open(Level)}).
+
 %% @spec get_header_value(string() | atom() | binary(), response()) ->
 %%           string() | undefined
 %% @doc Get the value of the given response header.
 get_header_value(K,
-		 {?MODULE, [_Request, _Code, Headers]}) ->
+		 {?MODULE, [_Request, _Code, Headers | _]}) ->
     mochiweb_headers:get_value(K, Headers).
 
 %% @spec get(request | code | headers, response()) -> term()
 %% @doc Return the internal representation of the given field.
-get(request, {?MODULE, [Request, _Code, _Headers]}) ->
+get(request, {?MODULE, [Request, _Code, _Headers | _]}) ->
     Request;
-get(code, {?MODULE, [_Request, Code, _Headers]}) ->
+get(code, {?MODULE, [_Request, Code, _Headers | _]}) ->
     Code;
-get(headers, {?MODULE, [_Request, _Code, Headers]}) ->
+get(headers, {?MODULE, [_Request, _Code, Headers | _]}) ->
     Headers.
 
 %% @spec dump(response()) -> {mochiweb_request, [{atom(), term()}]}
 %% @doc Dump the internal representation to a "human readable" set of terms
 %%      for debugging/inspection purposes.
-dump({?MODULE, [{ReqM, _} = Request, Code, Headers]}) ->
+dump({?MODULE, [{ReqM, _} = Request, Code, Headers | _]}) ->
     [{request, ReqM:dump(Request)}, {code, Code},
      {headers, mochiweb_headers:to_list(Headers)}].
 
 %% @spec send(iodata(), response()) -> ok
 %% @doc Send data over the socket if the method is not HEAD.
 send(Data,
-     {?MODULE, [{ReqM, _} = Request, _Code, _Headers]}) ->
+     {?MODULE, [{ReqM, _} = Request, _Code, _Headers | _]}) ->
     case ReqM:get(method, Request) of
       'HEAD' -> ok;
       _ -> ReqM:send(Data, Request)
@@ -72,10 +102,87 @@ send(Data,
 
 %% @spec write_chunk(iodata(), response()) -> ok
 %% @doc Write a chunk of a HTTP chunked response. If Data is zero length,
-%%      then the chunked response will be finished.
+%%      then the chunked response will be finished. For a response with an
+%%      enoder that also finishes the compression stream.
 write_chunk(Data,
-	    {?MODULE, [{ReqM, _} = Request, _Code, _Headers]} =
-		THIS) ->
+	    {?MODULE, [_Request, _Code, _Headers, Encoder]} = THIS) ->
+    case iolist_size(Data) of
+      0 ->
+	  Tail = encoder_finish(Encoder),
+	  case iolist_size(Tail) of
+	    0 -> ok;
+	    _ -> write_raw_chunk(Tail, THIS)
+	  end,
+	  write_raw_chunk(<<>>, THIS);
+      _ ->
+	  Compressed = encoder_data(Encoder, Data),
+	  case iolist_size(Compressed) of
+	    0 -> ok;
+	    _ -> write_raw_chunk(Compressed, THIS)
+	  end
+    end;
+write_chunk(Data, {?MODULE, _} = THIS) ->
+    write_raw_chunk(Data, THIS).
+
+%% Codec helpers. We expect both gzip and zstd to flush on each call. That's why
+%% we gated zstd to OTP 29+ since it has the flush call implemented
+encoder_data({gzip, Z}, Data) ->
+    zlib:deflate(Z, Data, sync);
+encoder_data({zstd, Ctx}, Data) ->
+    zstd_data(Ctx, Data).
+
+encoder_finish({gzip, Z}) ->
+    Tail = zlib:deflate(Z, <<>>, finish),
+    ok = zlib:deflateEnd(Z),
+    ok = zlib:close(Z),
+    Tail;
+encoder_finish({zstd, Ctx}) ->
+    zstd_finish(Ctx).
+
+-if(?OTP_RELEASE >= 29).
+
+zstd_supported() ->
+    [zstd].
+
+zstd_open(Level) ->
+    {ok, Ctx} = zstd:context(compress, #{compressionLevel => Level}),
+    Ctx.
+
+zstd_data(Ctx, Data) ->
+    zstd_data(Ctx, Data, []).
+
+zstd_data(Ctx, Data, Acc) ->
+    case zstd:stream(Ctx, Data) of
+      {continue, Output} ->
+          {continue, Flushed} = zstd:flush(Ctx),
+          lists:reverse([Flushed, Output | Acc]);
+      {continue, Rest, Output} ->
+          zstd_data(Ctx, Rest, [Output | Acc])
+    end.
+
+zstd_finish(Ctx) ->
+    {done, Tail} = zstd:finish(Ctx, <<>>),
+    ok = zstd:close(Ctx),
+    Tail.
+
+-else.
+
+zstd_supported() ->
+    [].
+
+zstd_open(_Level) ->
+    erlang:error({unsupported_encoder, zstd}).
+
+zstd_data(_Ctx, _Data) ->
+    erlang:error({unsupported_encoder, zstd}).
+
+zstd_finish(_Ctx) ->
+    erlang:error({unsupported_encoder, zstd}).
+
+-endif.
+
+write_raw_chunk(Data,
+		{?MODULE, [{ReqM, _} = Request | _]} = THIS) ->
     case ReqM:get(version, Request) of
       Version when Version >= {1, 1} ->
 	  Length = iolist_size(Data),

--- a/test/mochiweb_http_tests.erl
+++ b/test/mochiweb_http_tests.erl
@@ -44,6 +44,167 @@ chunked_encoding_test() ->
     ),
     ?assertEqual(ok, Res).
 
+gzip_chunked_server(Req) ->
+    Resp = mochiweb_request:respond(
+        {
+            200,
+            [{"Content-Type", "application/json"},
+             {"Content-Encoding", "gzip"}],
+            {chunked, {gzip, 1}}
+        },
+        Req
+    ),
+    mochiweb_response:write_chunk(<<"{\"rows\":[">>, Resp),
+    mochiweb_response:write_chunk(<<"{\"id\":1},">>, Resp),
+    mochiweb_response:write_chunk(<<"\n">>, Resp),
+    mochiweb_response:write_chunk(<<"{\"id\":2}]}">>, Resp),
+    mochiweb_response:write_chunk(<<>>, Resp),
+    Resp.
+
+gzip_chunked_client(Transport, Port) ->
+    SockFun = mochiweb_test_util:sock_fun(Transport, Port),
+    ok = SockFun({setopts, [{packet, http}]}),
+    ok = SockFun({send, ["GET / HTTP/1.1\r\n",
+                         "Host: localhost\r\n",
+                         "Accept-Encoding: gzip\r\n",
+                         "Connection: close\r\n",
+                         "\r\n"]}),
+    {ok, {http_response, {1, 1}, 200, _}} = SockFun(recv),
+    Headers = mochiweb_test_util:read_server_headers(SockFun),
+    ?assertEqual("gzip", mochiweb_headers:get_value("Content-Encoding", Headers)),
+    ?assertEqual("chunked", mochiweb_headers:get_value("Transfer-Encoding", Headers)),
+    Chunks = read_chunks(SockFun),
+    %% Expect 4 writes => 4 flushs with one final gzip trailer
+    ?assertEqual(5, length(Chunks)),
+    ?assertEqual(<<"{\"rows\":[{\"id\":1},\n{\"id\":2}]}">>, zlib:gunzip(Chunks)),
+    ok.
+
+read_chunks(SockFun) ->
+    ok = SockFun({setopts, [{packet, line}]}),
+    {ok, SizeLine} = SockFun(recv),
+    Size = list_to_integer(string:trim(binary_to_list(SizeLine)), 16),
+    case Size of
+        0 ->
+            {ok, <<"\r\n">>} = SockFun(recv),
+            [];
+        _ ->
+            ok = SockFun({setopts, [{packet, raw}]}),
+            {ok, Chunk} = SockFun({recv, Size}),
+            {ok, <<"\r\n">>} = SockFun({recv, 2}),
+            [Chunk | read_chunks(SockFun)]
+    end.
+
+gzip_chunked_encoding_test() ->
+    Res = mochiweb_test_util:with_server(
+        plain,
+        fun gzip_chunked_server/1,
+        fun gzip_chunked_client/2
+    ),
+    ?assertEqual(ok, Res).
+
+-if(?OTP_RELEASE >= 29).
+
+zstd_chunked_server(Req) ->
+    Resp = mochiweb_request:respond(
+        {
+            200,
+            [{"Content-Type", "application/json"},
+             {"Content-Encoding", "zstd"}],
+            {chunked, {zstd, 1}}
+        },
+        Req
+    ),
+    mochiweb_response:write_chunk(<<"{\"rows\":[">>, Resp),
+    mochiweb_response:write_chunk(<<"{\"id\":1},">>, Resp),
+    mochiweb_response:write_chunk(<<"\n">>, Resp),
+    mochiweb_response:write_chunk(<<"{\"id\":2}]}">>, Resp),
+    mochiweb_response:write_chunk(<<>>, Resp),
+    Resp.
+
+zstd_chunked_client(Transport, Port) ->
+    {Headers, Chunks} = read_zstd_response(Transport, Port),
+    ?assertEqual("zstd", mochiweb_headers:get_value("Content-Encoding", Headers)),
+    ?assertEqual("chunked", mochiweb_headers:get_value("Transfer-Encoding", Headers)),
+    %% 4 writes => 4 chunks + ending trailer
+    ?assertEqual(5, length(Chunks)),
+    ?assertEqual(
+        <<"{\"rows\":[{\"id\":1},\n{\"id\":2}]}">>,
+        iolist_to_binary(zstd:decompress(Chunks))
+    ),
+    ok.
+
+%% Here we're getting coverage for the large zstd:stream/2 input to it returns
+%% a {continue, Rest, Output} kind of a result
+zstd_big_chunk_server(Req) ->
+    Resp = mochiweb_request:respond(
+        {
+            200,
+            [{"Content-Type", "application/json"},
+             {"Content-Encoding", "zstd"}],
+            {chunked, {zstd, 1}}
+        },
+        Req
+    ),
+    mochiweb_response:write_chunk(big_payload(), Resp),
+    mochiweb_response:write_chunk(<<>>, Resp),
+    Resp.
+
+zstd_big_chunk_client(Transport, Port) ->
+    {_Headers, Chunks} = read_zstd_response(Transport, Port),
+    ?assertEqual(big_payload(), iolist_to_binary(zstd:decompress(Chunks))),
+    ok.
+
+big_payload() ->
+    %% something that doesn't compress too well
+    _ = rand:seed(exsss, {1, 2, 3}),
+    rand:bytes(1024 * 1024).
+
+read_zstd_response(Transport, Port) ->
+    SockFun = mochiweb_test_util:sock_fun(Transport, Port),
+    ok = SockFun({setopts, [{packet, http}]}),
+    ok = SockFun({send, ["GET / HTTP/1.1\r\n",
+                         "Host: localhost\r\n",
+                         "Accept-Encoding: zstd\r\n",
+                         "Connection: close\r\n",
+                         "\r\n"]}),
+    {ok, {http_response, {1, 1}, 200, _}} = SockFun(recv),
+    Headers = mochiweb_test_util:read_server_headers(SockFun),
+    {Headers, read_chunks(SockFun)}.
+
+zstd_chunked_encoding_test() ->
+    Res = mochiweb_test_util:with_server(
+        plain,
+        fun zstd_chunked_server/1,
+        fun zstd_chunked_client/2
+    ),
+    ?assertEqual(ok, Res).
+
+zstd_big_chunk_test() ->
+    Res = mochiweb_test_util:with_server(
+        plain,
+        fun zstd_big_chunk_server/1,
+        fun zstd_big_chunk_client/2
+    ),
+    ?assertEqual(ok, Res).
+
+-else.
+
+%% For belt and suspenders on releases < OTP-29 if the user code somehow
+%% start writing zstd chunks we'd like a clear error of what's happening
+zstd_unsupported_fails_early_test() ->
+    Req = mochiweb_request:new(
+        nil, [], 'GET', "/", {1, 1}, mochiweb_headers:make([])
+    ),
+    ?assertError(
+        {unsupported_encoder, zstd},
+        mochiweb_request:respond(
+            {200, [{"Content-Encoding", "zstd"}], {chunked, {zstd, 1}}},
+            Req
+        )
+    ).
+
+-endif.
+
 has_acceptor_bug_tests(Server) ->
     Port = mochiweb_socket_server:get(Server, port),
     [{"1000 should be fine even with the bug",


### PR DESCRIPTION
Both gzip and zstd are built-in Erlang/OTP compression methods. zstd is relatively new on OTP 29+ so it's gated as such.

To use compression call `respond({Code, Headers, {chunked, {Codec, Level}}}, Req), with Codec = gzip | zstd`. After that chunks will be transparently compressed with the corresponding codecs. Empty chunks finish the response and if there is compression involved also flush and close the contexts.

Since compression can buffer for quite a while, to avoid breaking heartbeats or interfering with timeouts, every chunk write also flushes compressed data. That's why we used OTP 29+, since it added the zstd flush() call (it wasn't there before in OTP 28 when zstd was introduced).