### PR TITLE
Add one-shot response compression

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -471,7 +471,10 @@ format_response_header({Code, ResponseHeaders, Length},
 %%      client (if the get(method) /= 'HEAD'). The Content-Length header
 %%      will be set by the Body length, and the server will insert header
 %%      defaults. A {chunked, {Codec = gzip|zstd, Level}} body starts a chunked
-%%      response with chunks compressed by write_chunk/2
+%%      response with chunks compressed by write_chunk/2. A
+%%      {compressed, {Codec, Level}, Body} body sends Body compressed in
+%%      one pass. Both set the matching Content-Encoding header
+%%      automatically.
 respond({Code, ResponseHeaders, {file, IoDevice}},
 	{?MODULE,
 	 [_Socket, _Opts, Method, _RawPath, _Version,
@@ -527,12 +530,34 @@ respond({Code, ResponseHeaders, {chunked, {Codec, Level}}},
       true -> ok;
       false -> erlang:error({unsupported_encoder, Codec})
     end,
-    Response = respond({Code, ResponseHeaders, chunked}, THIS),
+    HResponse = mochiweb_headers:insert("Content-Encoding",
+					atom_to_list(Codec),
+					mochiweb_headers:make(ResponseHeaders)),
+    Response = respond({Code, HResponse, chunked}, THIS),
     case Method of
       %% For HEAD we don't have a body so we don't compress anything
       'HEAD' -> Response;
       _ -> mochiweb_response:encoder(Codec, Level, Response)
     end;
+respond({Code, ResponseHeaders,
+	 {compressed, {Codec, Level}, Body}},
+	{?MODULE,
+	 [_Socket, _Opts, _Method, _RawPath, _Version,
+	  _Headers]} =
+	    THIS)
+    when Codec =:= gzip; Codec =:= zstd ->
+    %% Check for unsupported codecs (for ex. zstd on OTP < 29)
+    case lists:member(Codec, mochiweb_response:supported_encoders()) of
+      true -> ok;
+      false -> erlang:error({unsupported_encoder, Codec})
+    end,
+    %% Compress here and set the encoding header, then pass on to the next
+    %% clause to set the content-length properly based on the compressed body.
+    HResponse = mochiweb_headers:insert("Content-Encoding",
+					atom_to_list(Codec),
+					mochiweb_headers:make(ResponseHeaders)),
+    Compressed = mochiweb_response:compress(Codec, Level, Body),
+    respond({Code, HResponse, Compressed}, THIS);
 respond({Code, ResponseHeaders, Body},
 	{?MODULE,
 	 [_Socket, _Opts, Method, _RawPath, _Version,

--- a/src/mochiweb_response.erl
+++ b/src/mochiweb_response.erl
@@ -28,7 +28,7 @@
 -define(QUIP, "Any of you quaids got a smint?").
 
 -export([dump/1, get/2, get_header_value/2, new/3, new/4,
-	 encoder/3, supported_encoders/0]).
+	 encoder/3, compress/3, supported_encoders/0]).
 
 -export([send/2, write_chunk/2]).
 
@@ -57,16 +57,27 @@ supported_encoders() ->
 %% @doc Return a response so that its write_chunk/2 compresses each chunk with
 %%      the given codec. Every chunk is flushed so bytes are written
 %%      out immediately. Empty chunk that finishes a chunked response will end the
-%%      compression stream. The caller should include the matching content-encoding
-%%      response header.
+%%      compression stream. In mochiweb_request:respond/2 we set the matching
+%%      Content-Encoding header but callers using encoder/3 directly should
+%%      set it themselves.
 encoder(gzip, Level, {?MODULE, [Request, Code, Headers]}) ->
-    Z = zlib:open(),
-    %% 16 + 15 is gzip framing with the maximum window size
-    %% (from zlib.erl gzip/1)
-    ok = zlib:deflateInit(Z, Level, deflated, 16 + 15, 8, default),
+    Z = zlib_gzip_init(Level),
     new(Request, Code, Headers, {gzip, Z});
 encoder(zstd, Level, {?MODULE, [Request, Code, Headers]}) ->
     new(Request, Code, Headers, {zstd, zstd_open(Level)}).
+
+%% @spec compress(encoding(), integer(), iodata()) -> iodata()
+%% @doc Compress a whole body in one pass with the given codec. Used by
+%%      mochiweb_request:respond/2 for {compressed, {Codec, Level}, Body}
+%%      bodies, which also sets the matching Content-Encoding header.
+compress(gzip, Level, Body) ->
+    Z = zlib_gzip_init(Level),
+    Compressed = zlib:deflate(Z, Body, finish),
+    ok = zlib:deflateEnd(Z),
+    ok = zlib:close(Z),
+    Compressed;
+compress(zstd, Level, Body) ->
+    zstd_oneshot(Level, Body).
 
 %% @spec get_header_value(string() | atom() | binary(), response()) ->
 %%           string() | undefined
@@ -124,6 +135,12 @@ write_chunk(Data,
 write_chunk(Data, {?MODULE, _} = THIS) ->
     write_raw_chunk(Data, THIS).
 
+zlib_gzip_init(Level) ->
+    Z = zlib:open(),
+    %% 16 + 15 is gzip framing with the maximum window size (from zlib.erl gzip/1)
+    ok = zlib:deflateInit(Z, Level, deflated, 16 + 15, 8, default),
+    Z.
+
 %% Codec helpers. We expect both gzip and zstd to flush on each call. That's why
 %% we gated zstd to OTP 29+ since it has the flush call implemented
 encoder_data({gzip, Z}, Data) ->
@@ -165,6 +182,9 @@ zstd_finish(Ctx) ->
     ok = zstd:close(Ctx),
     Tail.
 
+zstd_oneshot(Level, Body) ->
+    zstd:compress(Body, #{compressionLevel => Level}).
+
 -else.
 
 zstd_supported() ->
@@ -177,6 +197,9 @@ zstd_data(_Ctx, _Data) ->
     erlang:error({unsupported_encoder, zstd}).
 
 zstd_finish(_Ctx) ->
+    erlang:error({unsupported_encoder, zstd}).
+
+zstd_oneshot(_Level, _Body) ->
     erlang:error({unsupported_encoder, zstd}).
 
 -endif.

--- a/test/mochiweb_http_tests.erl
+++ b/test/mochiweb_http_tests.erl
@@ -45,11 +45,11 @@ chunked_encoding_test() ->
     ?assertEqual(ok, Res).
 
 gzip_chunked_server(Req) ->
+    %% Content-Encoding is set by respond/2 from the codec
     Resp = mochiweb_request:respond(
         {
             200,
-            [{"Content-Type", "application/json"},
-             {"Content-Encoding", "gzip"}],
+            [{"Content-Type", "application/json"}],
             {chunked, {gzip, 1}}
         },
         Req
@@ -102,14 +102,57 @@ gzip_chunked_encoding_test() ->
     ),
     ?assertEqual(ok, Res).
 
+oneshot_payload() ->
+    iolist_to_binary(lists:duplicate(100, <<"{\"key\": \"value\"}, ">>)).
+
+gzip_oneshot_server(Req) ->
+    %% Content-Encoding is set by respond/2 from the codec
+    mochiweb_request:respond(
+        {
+            200,
+            [{"Content-Type", "application/json"}],
+            {compressed, {gzip, 1}, oneshot_payload()}
+        },
+        Req
+    ).
+
+gzip_oneshot_client(Transport, Port) ->
+    {Headers, Body} = read_oneshot_response(Transport, Port, "gzip"),
+    ?assertEqual("gzip", mochiweb_headers:get_value("Content-Encoding", Headers)),
+    ?assertEqual(oneshot_payload(), zlib:gunzip(Body)),
+    ok.
+
+read_oneshot_response(Transport, Port, Encoding) ->
+    SockFun = mochiweb_test_util:sock_fun(Transport, Port),
+    ok = SockFun({setopts, [{packet, http}]}),
+    ok = SockFun({send, ["GET / HTTP/1.1\r\n",
+                         "Host: localhost\r\n",
+                         "Accept-Encoding: ", Encoding, "\r\n",
+                         "Connection: close\r\n",
+                         "\r\n"]}),
+    {ok, {http_response, {1, 1}, 200, _}} = SockFun(recv),
+    Headers = mochiweb_test_util:read_server_headers(SockFun),
+    Length = list_to_integer(
+        mochiweb_headers:get_value("Content-Length", Headers)
+    ),
+    {Headers, mochiweb_test_util:drain_reply(SockFun, Length, <<>>)}.
+
+gzip_oneshot_test() ->
+    Res = mochiweb_test_util:with_server(
+        plain,
+        fun gzip_oneshot_server/1,
+        fun gzip_oneshot_client/2
+    ),
+    ?assertEqual(ok, Res).
+
 -if(?OTP_RELEASE >= 29).
 
 zstd_chunked_server(Req) ->
+    %% Content-Encoding is set by respond/2 from the codec
     Resp = mochiweb_request:respond(
         {
             200,
-            [{"Content-Type", "application/json"},
-             {"Content-Encoding", "zstd"}],
+            [{"Content-Type", "application/json"}],
             {chunked, {zstd, 1}}
         },
         Req
@@ -139,8 +182,7 @@ zstd_big_chunk_server(Req) ->
     Resp = mochiweb_request:respond(
         {
             200,
-            [{"Content-Type", "application/json"},
-             {"Content-Encoding", "zstd"}],
+            [{"Content-Type", "application/json"}],
             {chunked, {zstd, 1}}
         },
         Req
@@ -187,6 +229,30 @@ zstd_big_chunk_test() ->
     ),
     ?assertEqual(ok, Res).
 
+zstd_oneshot_server(Req) ->
+    mochiweb_request:respond(
+        {
+            200,
+            [{"Content-Type", "application/json"}],
+            {compressed, {zstd, 1}, oneshot_payload()}
+        },
+        Req
+    ).
+
+zstd_oneshot_client(Transport, Port) ->
+    {Headers, Body} = read_oneshot_response(Transport, Port, "zstd"),
+    ?assertEqual("zstd", mochiweb_headers:get_value("Content-Encoding", Headers)),
+    ?assertEqual(oneshot_payload(), iolist_to_binary(zstd:decompress(Body))),
+    ok.
+
+zstd_oneshot_test() ->
+    Res = mochiweb_test_util:with_server(
+        plain,
+        fun zstd_oneshot_server/1,
+        fun zstd_oneshot_client/2
+    ),
+    ?assertEqual(ok, Res).
+
 -else.
 
 %% For belt and suspenders on releases < OTP-29 if the user code somehow
@@ -198,7 +264,7 @@ zstd_unsupported_fails_early_test() ->
     ?assertError(
         {unsupported_encoder, zstd},
         mochiweb_request:respond(
-            {200, [{"Content-Encoding", "zstd"}], {chunked, {zstd, 1}}},
+            {200, [], {chunked, {zstd, 1}}},
             Req
         )
     ).


### PR DESCRIPTION
Previously, we set it for chunked responses as it takes more effort to carry the context across, but for symmetry it would be nice to also set it for one-shot (non-chunked) responses.

Also, since we already pass in a codec option for both one-shot and chunked, let's also set the appropriate content-encoding header. There is less chance of users forgetting or making a mistake (we still guard on un supported codec usage).